### PR TITLE
Extend gitignore to cover OS files and test.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,62 @@
+### Windows ###
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+
+### OSX ###
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+### Linux ###
+*~
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+
+### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -55,3 +114,8 @@ docs/_build/
 
 # PyBuilder
 target/
+
+
+### Rhythm ###
+test.ini
+


### PR DESCRIPTION
Cover OS files in gitignore file, since silly systems like OS X enjoy making useless files.

Also ignores `test.ini`, a file I'm gonna use for my own testing configuration (so it doesn't register `config.ini` as a dirty file because I've changed it to point to localhost).