### PR TITLE
Add MongoDB database integration, fixes #5

### DIFF
--- a/config.orig.ini
+++ b/config.orig.ini
@@ -18,6 +18,11 @@ includes =
 autojoins =
     PPAU-PWG
 
+# mongo database connection uri
+# if not using a database, comment these lines
+name = motionbot
+database = mongodb://localhost:27017/
+
 [irc3.plugins.command]
 # set command char
 cmd = !

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 docopt==0.6.2
 irc3==0.8.1
+pymongo==3.0.3
 venusian==1.0
 wheel==0.24.0


### PR DESCRIPTION
This adds MongoDB integration, using the same database format as the original Motionbot, so Motionbot should be able to be replaced with Rhythm without issue (once the other issues are worked out). The database is designed to be optional, and the bot can be run with or without it.